### PR TITLE
Don't highlight spaces around "<OK>" on focus

### DIFF
--- a/src/app/tests/empty.rs
+++ b/src/app/tests/empty.rs
@@ -33,7 +33,7 @@ mod areas {
 
     pub(super) const SCREEN: Rect = Rect::new(0, 0, 80, 24);
 
-    pub(super) const OK: Rect = Rect::new(26, 0, 8, 1);
+    pub(super) const OK: Rect = Rect::new(28, 0, 4, 1);
     pub(super) const CANCEL: Rect = Rect::new(46, 0, 8, 1);
 }
 

--- a/src/app/tests/flavors.rs
+++ b/src/app/tests/flavors.rs
@@ -37,7 +37,7 @@ mod areas {
     //pub(super) const CHERRY: Rect = Rect::new(OPTION_INDENT, 13, OPTION_HIGHLIGHT_WIDTH, 1);
     pub(super) const BANANA: Rect = Rect::new(OPTION_INDENT, 14, OPTION_HIGHLIGHT_WIDTH, 1);
 
-    pub(super) const OK: Rect = Rect::new(26, 16, 8, 1);
+    pub(super) const OK: Rect = Rect::new(28, 16, 4, 1);
     pub(super) const CANCEL: Rect = Rect::new(46, 16, 8, 1);
 }
 

--- a/src/app/widgets.rs
+++ b/src/app/widgets.rs
@@ -1,5 +1,10 @@
 use super::{HIGHLIGHT_STYLE, TITLE_STYLE};
-use ratatui::{buffer::Buffer, layout::Rect, text::Line, widgets::Widget};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    text::{Line, Span},
+    widgets::Widget,
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct ListTitle<'a>(pub(super) &'a str);
@@ -68,11 +73,11 @@ pub(super) struct OkButton(pub(super) bool);
 
 impl Widget for OkButton {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let mut wdgt = Line::from("<OK>").centered();
+        let mut wdgt = Span::from("<OK>");
         if self.0 {
             wdgt = wdgt.style(HIGHLIGHT_STYLE);
         }
-        wdgt.render(area, buf);
+        wdgt.into_centered_line().render(area, buf);
     }
 }
 
@@ -81,10 +86,10 @@ pub(super) struct CancelButton(pub(super) bool);
 
 impl Widget for CancelButton {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let mut wdgt = Line::from("<Cancel>").centered();
+        let mut wdgt = Span::from("<Cancel>");
         if self.0 {
             wdgt = wdgt.style(HIGHLIGHT_STYLE);
         }
-        wdgt.render(area, buf);
+        wdgt.into_centered_line().render(area, buf);
     }
 }


### PR DESCRIPTION
Closes #8.