### PR TITLE
Implement `PageUp` and `PageDown`

### DIFF
--- a/examples/multipage.rs
+++ b/examples/multipage.rs
@@ -1,0 +1,26 @@
+use ratselect::{Form, RadioSelector, Selection};
+
+fn main() -> std::io::Result<()> {
+    let mut app = Form::new();
+    for (ch, qty) in std::iter::zip("ABCDE".chars(), 16..) {
+        app.add(
+            ch,
+            RadioSelector::new(format!("List {ch}"), (0..qty).map(|i| format!("{ch}{i}"))),
+        );
+    }
+    let selections = app.run()?;
+    if std::env::args_os().nth(1).is_some_and(|s| s == "--debug") {
+        println!("{selections:#?}");
+    } else if let Some(selections) = selections {
+        for (k, v) in selections {
+            if let Selection::Radio(i) = v {
+                println!("List {k}: {k}{i}");
+            } else {
+                println!("UNEXPECTED OUTPUT: ({k:?}, {v:?})");
+            }
+        }
+    } else {
+        println!("User quit");
+    }
+    Ok(())
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -166,8 +166,8 @@ impl<T> App<T> {
                     self.focus = Focus::OkButton;
                 }
             }
+            self.adjscroll();
         }
-        // TODO: Scroll
     }
 
     fn move_up(&mut self) {
@@ -183,12 +183,14 @@ impl<T> App<T> {
                         option,
                         index: index - 1,
                     };
+                    self.adjscroll();
                 } else if let Some(list) = list.checked_sub(1) {
                     self.focus = Focus::Item {
                         list,
                         option: self.lists[list].len() - 1,
                         index: index - 3,
                     };
+                    self.adjscroll();
                 }
                 // Else: We're at the top
             }
@@ -199,11 +201,11 @@ impl<T> App<T> {
                         option: self.lists[list].len() - 1,
                         index: self.elements.len() - 3,
                     };
+                    self.adjscroll();
                 }
                 // Else: content is empty; can't move up
             }
         }
-        // TODO: Scroll
     }
 
     fn move_right(&mut self) {
@@ -226,18 +228,19 @@ impl<T> App<T> {
         if self.is_empty() {
             self.focus = Focus::OkButton;
         } else {
+            self.scroll_offset = 0;
             self.focus = Focus::Item {
                 list: 0,
                 option: 0,
                 index: 1,
             };
-            // TODO: Scroll
+            self.adjscroll();
         }
     }
 
     fn goto_bottom(&mut self) {
         self.focus = Focus::OkButton;
-        // TODO: Scroll
+        self.adjscroll();
     }
 
     fn next_block(&mut self) {
@@ -273,7 +276,7 @@ impl<T> App<T> {
                 }
             }
         }
-        // TODO: Scroll
+        self.adjscroll();
     }
 
     fn prev_block(&mut self) {
@@ -306,7 +309,40 @@ impl<T> App<T> {
             }
             Focus::CancelButton => self.focus = Focus::OkButton,
         }
-        // TODO: Scroll
+        self.adjscroll();
+    }
+
+    fn adjscroll(&mut self) {
+        if let Some(screen_height) = self.screen_height {
+            match self.focus {
+                Focus::Item { index, .. } => {
+                    if index < self.scroll_offset {
+                        self.scroll_offset = index;
+                    } else {
+                        let mut depth = self.elements[self.scroll_offset..=index]
+                            .iter()
+                            .map(Element::height)
+                            .sum::<u16>();
+                        while depth > screen_height && self.scroll_offset < index {
+                            // Scroll down one full item
+                            depth -= self.elements[self.scroll_offset].height();
+                            self.scroll_offset += 1;
+                        }
+                    }
+                }
+                Focus::OkButton | Focus::CancelButton => {
+                    let mut depth = self.elements[self.scroll_offset..]
+                        .iter()
+                        .map(Element::height)
+                        .sum::<u16>();
+                    while depth > screen_height && self.scroll_offset < self.elements.len() - 1 {
+                        // Scroll down one full item
+                        depth -= self.elements[self.scroll_offset].height();
+                        self.scroll_offset += 1;
+                    }
+                }
+            }
+        }
     }
 
     fn activate(&mut self) {
@@ -425,7 +461,12 @@ impl<T> Widget for &mut App<T> {
             Layout::horizontal([Constraint::Fill(1), Constraint::Length(1)]).areas(area);
         self.screen_height = Some(area.height);
         let max_scroll = wi.total_lines.saturating_sub(usize::from(area.height) - 1);
-        for (i, elem) in wi.elements.iter().enumerate().skip(self.scroll_offset) {
+        let mut scroll_position = 0;
+        for (i, elem) in wi.elements.iter().enumerate() {
+            if i < self.scroll_offset {
+                scroll_position += usize::from(elem.height());
+                continue;
+            }
             if area.is_empty() {
                 break;
             }
@@ -499,7 +540,7 @@ impl<T> Widget for &mut App<T> {
         if wi.total_lines > usize::from(area.height) {
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .track_symbol(Some(ratatui::symbols::shade::MEDIUM));
-            let mut scroll_state = ScrollbarState::new(max_scroll).position(self.scroll_offset);
+            let mut scroll_state = ScrollbarState::new(max_scroll).position(scroll_position);
             scrollbar.render(scrollbar_area, buf, &mut scroll_state);
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -34,6 +34,8 @@ pub(crate) struct App<T> {
     /// Did the user end the form by pressing "OK"?
     ok: bool,
     wrap_cache: Option<WrapCache>,
+    /// Number of elements of `elements` that are above the top of the screen
+    offset: usize,
 }
 
 impl<T> App<T> {
@@ -141,15 +143,24 @@ impl<T> App<T> {
         if let Focus::Item {
             mut list,
             mut option,
+            index,
         } = self.focus
         {
             option += 1;
             if option < self.lists[list].len() {
-                self.focus = Focus::Item { list, option };
+                self.focus = Focus::Item {
+                    list,
+                    option,
+                    index: index + 1,
+                };
             } else {
                 list += 1;
                 if list < self.lists.len() {
-                    self.focus = Focus::Item { list, option: 0 };
+                    self.focus = Focus::Item {
+                        list,
+                        option: 0,
+                        index: index + 3,
+                    };
                 } else {
                     self.focus = Focus::OkButton;
                 }
@@ -160,13 +171,22 @@ impl<T> App<T> {
 
     fn move_up(&mut self) {
         match self.focus {
-            Focus::Item { list, option } => {
+            Focus::Item {
+                list,
+                option,
+                index,
+            } => {
                 if let Some(option) = option.checked_sub(1) {
-                    self.focus = Focus::Item { list, option };
+                    self.focus = Focus::Item {
+                        list,
+                        option,
+                        index: index - 1,
+                    };
                 } else if let Some(list) = list.checked_sub(1) {
                     self.focus = Focus::Item {
                         list,
                         option: self.lists[list].len() - 1,
+                        index: index - 3,
                     };
                 }
                 // Else: We're at the top
@@ -176,6 +196,7 @@ impl<T> App<T> {
                     self.focus = Focus::Item {
                         list,
                         option: self.lists[list].len() - 1,
+                        index: self.elements.len() - 3,
                     };
                 }
                 // Else: content is empty; can't move up
@@ -204,7 +225,11 @@ impl<T> App<T> {
         if self.is_empty() {
             self.focus = Focus::OkButton;
         } else {
-            self.focus = Focus::Item { list: 0, option: 0 };
+            self.focus = Focus::Item {
+                list: 0,
+                option: 0,
+                index: 1,
+            };
             // TODO: Scroll
         }
     }
@@ -216,10 +241,20 @@ impl<T> App<T> {
 
     fn next_block(&mut self) {
         match self.focus {
-            Focus::Item { mut list, .. } => {
+            Focus::Item {
+                mut list,
+                option,
+                mut index,
+                ..
+            } => {
+                index += self.lists[list].len() - option + 2;
                 list += 1;
                 if list < self.lists.len() {
-                    self.focus = Focus::Item { list, option: 0 };
+                    self.focus = Focus::Item {
+                        list,
+                        option: 0,
+                        index,
+                    };
                 } else {
                     self.focus = Focus::OkButton;
                 }
@@ -229,7 +264,11 @@ impl<T> App<T> {
                 if self.is_empty() {
                     self.focus = Focus::OkButton;
                 } else {
-                    self.focus = Focus::Item { list: 0, option: 0 };
+                    self.focus = Focus::Item {
+                        list: 0,
+                        option: 0,
+                        index: 1,
+                    };
                 }
             }
         }
@@ -238,16 +277,28 @@ impl<T> App<T> {
 
     fn prev_block(&mut self) {
         match self.focus {
-            Focus::Item { list, .. } => {
+            Focus::Item {
+                list,
+                option,
+                index,
+            } => {
                 if let Some(list) = list.checked_sub(1) {
-                    self.focus = Focus::Item { list, option: 0 };
+                    self.focus = Focus::Item {
+                        list,
+                        option: 0,
+                        index: index - option - self.lists[list].len() - 2,
+                    };
                 } else {
                     self.focus = Focus::CancelButton;
                 }
             }
             Focus::OkButton => {
                 if let Some(list) = self.lists.len().checked_sub(1) {
-                    self.focus = Focus::Item { list, option: 0 };
+                    self.focus = Focus::Item {
+                        list,
+                        option: 0,
+                        index: self.elements.len() - self.lists[list].len() - 2,
+                    };
                 } else {
                     self.focus = Focus::CancelButton;
                 }
@@ -259,7 +310,7 @@ impl<T> App<T> {
 
     fn activate(&mut self) {
         match self.focus {
-            Focus::Item { list, option } => self.lists[list].activate_option(option),
+            Focus::Item { list, option, .. } => self.lists[list].activate_option(option),
             Focus::OkButton => {
                 self.ok = true;
                 self.quitting = true;
@@ -361,7 +412,7 @@ impl<T> Widget for &mut App<T> {
         let (option_highlight_width, elements) = self.get_wrapped_elements(area.width);
         let [mut area, _scrollbar_area] =
             Layout::horizontal([Constraint::Fill(1), Constraint::Length(1)]).areas(area);
-        for elem in &*elements {
+        for (i, elem) in elements.iter().enumerate() {
             let [rows, a2] =
                 Layout::vertical([Constraint::Length(elem.height()), Constraint::Fill(1)])
                     .areas(area);
@@ -376,7 +427,12 @@ impl<T> Widget for &mut App<T> {
                     let wdgt = widgets::RadioOption {
                         label: text,
                         checked: self.lists[list].is_checked(option),
-                        focused: self.focus == (Focus::Item { list, option }),
+                        focused: self.focus
+                            == (Focus::Item {
+                                list,
+                                option,
+                                index: i,
+                            }),
                     };
                     let [_, line_area, _] = Layout::horizontal([
                         Constraint::Length(OPTION_INDENT),
@@ -392,7 +448,12 @@ impl<T> Widget for &mut App<T> {
                     let wdgt = widgets::MultiOption {
                         label: text,
                         checked: self.lists[list].is_checked(option),
-                        focused: self.focus == (Focus::Item { list, option }),
+                        focused: self.focus
+                            == (Focus::Item {
+                                list,
+                                option,
+                                index: i,
+                            }),
                     };
                     let [_, line_area, _] = Layout::horizontal([
                         Constraint::Length(OPTION_INDENT),
@@ -479,7 +540,11 @@ impl<T> From<Form<T>> for App<T> {
         let focus = if keys.is_empty() {
             Focus::OkButton
         } else {
-            Focus::Item { list: 0, option: 0 }
+            Focus::Item {
+                list: 0,
+                option: 0,
+                index: 1,
+            }
         };
         elements.push(Element::Buttons);
         App {
@@ -490,6 +555,7 @@ impl<T> From<Form<T>> for App<T> {
             quitting: false,
             ok: false,
             wrap_cache: None,
+            offset: 0,
         }
     }
 }
@@ -526,7 +592,19 @@ impl Element {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Focus {
-    Item { list: usize, option: usize },
+    Item {
+        /// Index within `App::lists` of the selection list within which the
+        /// focus is currently located
+        list: usize,
+
+        /// Index of the option of the focused selection list that has the
+        /// focus
+        option: usize,
+
+        /// Index within `App::elements` of the `RadioOption` or `MultiOption`
+        /// that has the focus
+        index: usize,
+    },
     OkButton,
     CancelButton,
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -246,11 +246,11 @@ impl<T> App<T> {
                 self.scroll_offset = focus_index;
                 let mut accum = wi.elements[self.scroll_offset].height();
                 while self.scroll_offset > 0 {
-                    self.scroll_offset -= 1;
-                    let h = wi.elements[self.scroll_offset].height();
+                    let h = wi.elements[self.scroll_offset - 1].height();
                     let acc2 = accum.saturating_add(h);
                     if acc2 <= screen_height {
                         accum = acc2;
+                        self.scroll_offset -= 1;
                     } else {
                         break;
                     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,7 +7,7 @@ use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Layout, Rect},
     style::Style,
-    widgets::Widget,
+    widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget, Widget},
 };
 use std::borrow::Cow;
 use std::collections::BTreeSet;
@@ -33,9 +33,10 @@ pub(crate) struct App<T> {
     quitting: bool,
     /// Did the user end the form by pressing "OK"?
     ok: bool,
-    wrap_cache: Option<WrapCache>,
+    wrap_cache: Option<Rc<WrapInfo>>,
     /// Number of elements of `elements` that are above the top of the screen
-    offset: usize,
+    scroll_offset: usize,
+    screen_height: Option<u16>,
 }
 
 impl<T> App<T> {
@@ -319,11 +320,11 @@ impl<T> App<T> {
         }
     }
 
-    fn get_wrapped_elements(&mut self, screen_width: u16) -> (u16, Rc<[Element]>) {
+    fn get_wrap_info(&mut self, screen_width: u16) -> Rc<WrapInfo> {
         if let Some(ref wc) = self.wrap_cache
             && wc.screen_width == screen_width
         {
-            (wc.option_highlight_width, Rc::clone(&wc.elements))
+            Rc::clone(wc)
         } else {
             let max_title_width = usize::from(screen_width.saturating_sub(1));
             let max_option_label_width = usize::from(screen_width.saturating_sub(
@@ -331,6 +332,7 @@ impl<T> App<T> {
             ));
             let mut option_highlight_width = 0;
             let mut elements = Vec::with_capacity(self.elements.len());
+            let mut total_lines = 0;
             for elem in &self.elements {
                 match elem {
                     Element::ListTitle(txt) => {
@@ -343,7 +345,8 @@ impl<T> App<T> {
                                 )
                             })
                             .map(Cow::into_owned)
-                            .collect();
+                            .collect::<Vec<_>>();
+                        total_lines += wrapped.len();
                         elements.push(Element::ListTitle(wrapped));
                     }
                     Element::RadioOption { list, option, text } => {
@@ -360,7 +363,8 @@ impl<T> App<T> {
                                 option_highlight_width = option_highlight_width.max(ln.width());
                             })
                             .map(Cow::into_owned)
-                            .collect();
+                            .collect::<Vec<_>>();
+                        total_lines += wrapped.len();
                         elements.push(Element::RadioOption {
                             list: *list,
                             option: *option,
@@ -381,38 +385,50 @@ impl<T> App<T> {
                                 option_highlight_width = option_highlight_width.max(ln.width());
                             })
                             .map(Cow::into_owned)
-                            .collect();
+                            .collect::<Vec<_>>();
+                        total_lines += wrapped.len();
                         elements.push(Element::MultiOption {
                             list: *list,
                             option: *option,
                             text: wrapped,
                         });
                     }
-                    Element::BlankLine => elements.push(Element::BlankLine),
-                    Element::Buttons => elements.push(Element::Buttons),
+                    Element::BlankLine => {
+                        total_lines += 1;
+                        elements.push(Element::BlankLine);
+                    }
+                    Element::Buttons => {
+                        total_lines += 1;
+                        elements.push(Element::Buttons);
+                    }
                 }
             }
-            let elements = Rc::<[Element]>::from(elements);
             let option_highlight_width = u16::try_from(option_highlight_width)
                 .unwrap_or(u16::MAX)
                 .saturating_add(4);
-            let r = (option_highlight_width, Rc::clone(&elements));
-            self.wrap_cache = Some(WrapCache {
+            let wi = Rc::new(WrapInfo {
                 screen_width,
                 option_highlight_width,
                 elements,
+                total_lines,
             });
-            r
+            self.wrap_cache = Some(Rc::clone(&wi));
+            wi
         }
     }
 }
 
 impl<T> Widget for &mut App<T> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let (option_highlight_width, elements) = self.get_wrapped_elements(area.width);
-        let [mut area, _scrollbar_area] =
+        let wi = self.get_wrap_info(area.width);
+        let [mut area, scrollbar_area] =
             Layout::horizontal([Constraint::Fill(1), Constraint::Length(1)]).areas(area);
-        for (i, elem) in elements.iter().enumerate() {
+        self.screen_height = Some(area.height);
+        let max_scroll = wi.total_lines.saturating_sub(usize::from(area.height) - 1);
+        for (i, elem) in wi.elements.iter().enumerate().skip(self.scroll_offset) {
+            if area.is_empty() {
+                break;
+            }
             let [rows, a2] =
                 Layout::vertical([Constraint::Length(elem.height()), Constraint::Fill(1)])
                     .areas(area);
@@ -436,7 +452,7 @@ impl<T> Widget for &mut App<T> {
                     };
                     let [_, line_area, _] = Layout::horizontal([
                         Constraint::Length(OPTION_INDENT),
-                        Constraint::Length(option_highlight_width),
+                        Constraint::Length(wi.option_highlight_width),
                         Constraint::Fill(1),
                     ])
                     .areas(rows);
@@ -457,7 +473,7 @@ impl<T> Widget for &mut App<T> {
                     };
                     let [_, line_area, _] = Layout::horizontal([
                         Constraint::Length(OPTION_INDENT),
-                        Constraint::Length(option_highlight_width),
+                        Constraint::Length(wi.option_highlight_width),
                         Constraint::Fill(1),
                     ])
                     .areas(rows);
@@ -479,6 +495,12 @@ impl<T> Widget for &mut App<T> {
                     cancel_button.render(cancel_area, buf);
                 }
             }
+        }
+        if wi.total_lines > usize::from(area.height) {
+            let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .track_symbol(Some(ratatui::symbols::shade::MEDIUM));
+            let mut scroll_state = ScrollbarState::new(max_scroll).position(self.scroll_offset);
+            scrollbar.render(scrollbar_area, buf, &mut scroll_state);
         }
     }
 }
@@ -555,7 +577,8 @@ impl<T> From<Form<T>> for App<T> {
             quitting: false,
             ok: false,
             wrap_cache: None,
-            offset: 0,
+            scroll_offset: 0,
+            screen_height: None,
         }
     }
 }
@@ -690,10 +713,11 @@ impl MultiData {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct WrapCache {
+struct WrapInfo {
     screen_width: u16,
     option_highlight_width: u16,
-    elements: Rc<[Element]>,
+    elements: Vec<Element>,
+    total_lines: usize,
 }
 
 fn split_lines(s: &str) -> Vec<String> {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -272,7 +272,6 @@ impl<T> App<T> {
             let mut accum = 0u16;
             let mut gotcha = false;
             for elem in &wi.elements[self.scroll_offset..] {
-                focus_index += 1;
                 accum = accum.saturating_add(elem.height());
                 if accum > screen_height {
                     match self.elements[focus_index] {
@@ -294,6 +293,7 @@ impl<T> App<T> {
                         _ => (),
                     }
                 }
+                focus_index += 1;
             }
             if !gotcha {
                 // There's nothing past the end of the screen, so just focus on

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -647,7 +647,9 @@ impl Element {
     fn height(&self) -> u16 {
         let len = match self {
             Element::ListTitle(txt) => txt.len(),
+            Element::RadioOption { text, .. } if text.is_empty() => 1,
             Element::RadioOption { text, .. } => text.len(),
+            Element::MultiOption { text, .. } if text.is_empty() => 1,
             Element::MultiOption { text, .. } => text.len(),
             Element::BlankLine => 1,
             Element::Buttons => 1,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10,6 +10,7 @@ use ratatui::{
     widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget, Widget},
 };
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::rc::Rc;
 use std::time::Duration;
@@ -118,8 +119,8 @@ impl<T> App<T> {
                 KeyCode::Char('j') | KeyCode::Down => self.move_down(),
                 KeyCode::Char('k') | KeyCode::Up => self.move_up(),
                 KeyCode::Char('l') | KeyCode::Right => self.move_right(),
-                //TODO: KeyCode::Char('w') | KeyCode::PageUp => self.page_up(),
-                //TODO: KeyCode::Char('z') | KeyCode::PageDown => self.page_down(),
+                KeyCode::Char('w') | KeyCode::PageUp => self.page_up(),
+                KeyCode::Char('z') | KeyCode::PageDown => self.page_down(),
                 KeyCode::Char('g') | KeyCode::Home => self.goto_top(),
                 KeyCode::Char('G') | KeyCode::End => self.goto_bottom(),
                 KeyCode::Tab => self.next_block(),
@@ -216,15 +217,112 @@ impl<T> App<T> {
         }
     }
 
-    /*
     fn page_up(&mut self) {
-        todo!()
+        if !self.is_empty()
+            && let Some(screen_height) = self.screen_height
+            && let Some(ref wi) = self.wrap_cache
+        {
+            // Move focus to lowest focusable item above top of screen.  If
+            // there is no such item, the focus will be left where it is, but
+            // the scroll offset will be set to 0.
+            let mut focus_index = self.scroll_offset;
+            while focus_index > 0 {
+                focus_index -= 1;
+                if let Element::RadioOption { list, option, .. }
+                | Element::MultiOption { list, option, .. } = self.elements[focus_index]
+                {
+                    self.focus = Focus::Item {
+                        list,
+                        option,
+                        index: focus_index,
+                    };
+                    break;
+                }
+            }
+            // Scroll so that the new focus is at the bottom of the screen,
+            // possibly followed by a cut-off multiline item
+            self.scroll_offset = focus_index;
+            let mut accum = wi.elements[self.scroll_offset].height();
+            while self.scroll_offset > 0 {
+                self.scroll_offset -= 1;
+                let h = wi.elements[self.scroll_offset].height();
+                let acc2 = accum.saturating_add(h);
+                if acc2 <= screen_height {
+                    accum = acc2;
+                } else {
+                    break;
+                }
+            }
+        }
     }
 
     fn page_down(&mut self) {
-        todo!()
+        if !self.is_empty()
+            && let Some(screen_height) = self.screen_height
+            && let Some(ref wi) = self.wrap_cache
+        {
+            // Move focus to first focusable item below the screen, or to the
+            // item at the bottom of the screen if it's cut in two
+            let mut focus_index = self.scroll_offset;
+            let mut accum = 0u16;
+            let mut gotcha = false;
+            for elem in &wi.elements[self.scroll_offset..] {
+                focus_index += 1;
+                accum = accum.saturating_add(elem.height());
+                if accum > screen_height {
+                    match self.elements[focus_index] {
+                        Element::RadioOption { list, option, .. }
+                        | Element::MultiOption { list, option, .. } => {
+                            self.focus = Focus::Item {
+                                list,
+                                option,
+                                index: focus_index,
+                            };
+                            gotcha = true;
+                            break;
+                        }
+                        Element::Buttons => {
+                            self.focus = Focus::OkButton;
+                            gotcha = true;
+                            break;
+                        }
+                        _ => (),
+                    }
+                }
+            }
+            if !gotcha {
+                // There's nothing past the end of the screen, so just focus on
+                // the "OK" button
+                self.focus = Focus::OkButton;
+                return;
+            }
+            // Scroll so that the new focus is at the top of the screen, but
+            // not so much that there's space below the buttons
+            self.scroll_offset = focus_index;
+            let mut accum = 0u16;
+            for elem in &wi.elements[self.scroll_offset..] {
+                accum = accum.saturating_add(elem.height());
+                if accum >= screen_height {
+                    return;
+                }
+            }
+            while self.scroll_offset > 0 {
+                let h = wi.elements[self.scroll_offset - 1].height();
+                let acc2 = accum.saturating_add(h);
+                match acc2.cmp(&screen_height) {
+                    Ordering::Less => {
+                        accum = acc2;
+                        self.scroll_offset -= 1;
+                    }
+                    Ordering::Equal => {
+                        self.scroll_offset -= 1;
+                        break;
+                    }
+                    Ordering::Greater => break,
+                }
+            }
+        }
     }
-    */
 
     fn goto_top(&mut self) {
         if self.is_empty() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -223,9 +223,9 @@ impl<T> App<T> {
             && let Some(ref wi) = self.wrap_cache
         {
             // Move focus to lowest focusable item above top of screen.  If
-            // there is no such item, the focus will be left where it is, but
-            // the scroll offset will be set to 0.
+            // there is no such item, scroll to top.
             let mut focus_index = self.scroll_offset;
+            let mut gotcha = false;
             while focus_index > 0 {
                 focus_index -= 1;
                 if let Element::RadioOption { list, option, .. }
@@ -236,22 +236,27 @@ impl<T> App<T> {
                         option,
                         index: focus_index,
                     };
+                    gotcha = true;
                     break;
                 }
             }
-            // Scroll so that the new focus is at the bottom of the screen,
-            // possibly followed by a cut-off multiline item
-            self.scroll_offset = focus_index;
-            let mut accum = wi.elements[self.scroll_offset].height();
-            while self.scroll_offset > 0 {
-                self.scroll_offset -= 1;
-                let h = wi.elements[self.scroll_offset].height();
-                let acc2 = accum.saturating_add(h);
-                if acc2 <= screen_height {
-                    accum = acc2;
-                } else {
-                    break;
+            if gotcha {
+                // Scroll so that the new focus is at the bottom of the screen,
+                // possibly followed by a cut-off multiline item
+                self.scroll_offset = focus_index;
+                let mut accum = wi.elements[self.scroll_offset].height();
+                while self.scroll_offset > 0 {
+                    self.scroll_offset -= 1;
+                    let h = wi.elements[self.scroll_offset].height();
+                    let acc2 = accum.saturating_add(h);
+                    if acc2 <= screen_height {
+                        accum = acc2;
+                    } else {
+                        break;
+                    }
                 }
+            } else {
+                self.goto_top();
             }
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -183,16 +183,18 @@ impl<T> App<T> {
                         option,
                         index: index - 1,
                     };
-                    self.adjscroll();
                 } else if let Some(list) = list.checked_sub(1) {
                     self.focus = Focus::Item {
                         list,
                         option: self.lists[list].len() - 1,
                         index: index - 3,
                     };
-                    self.adjscroll();
+                } else {
+                    // We're at the top option, but at least make sure the top
+                    // title is visible.
+                    self.scroll_offset = 0;
                 }
-                // Else: We're at the top
+                self.adjscroll();
             }
             Focus::OkButton | Focus::CancelButton => {
                 if let Some(list) = self.lists.len().checked_sub(1) {

--- a/src/app/tests/flavors.rs
+++ b/src/app/tests/flavors.rs
@@ -1318,6 +1318,14 @@ fn shift_tab_around() {
 
     app.handle_event(Event::Key(KeyCode::BackTab.into()));
     assert!(app.get_output().is_none());
+    assert_eq!(
+        app.focus,
+        Focus::Item {
+            list: 0,
+            option: 0,
+            index: 1
+        }
+    );
     let mut buffer = Buffer::empty(areas::SCREEN);
     app.render(areas::SCREEN, &mut buffer);
     let mut expected = Buffer::with_lines([

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -1,4 +1,5 @@
 mod empty;
 mod flavors;
 mod multiline;
+mod multipage;
 mod wrapped;

--- a/src/app/tests/multipage.rs
+++ b/src/app/tests/multipage.rs
@@ -499,6 +499,47 @@ fn scroll_down_one_line_then_back_up() {
     expected.set_style(Rect::new(0, 17, 79, 1), TITLE_STYLE); // "List B"
     expected.set_style(Rect::new(4, 0, 7, 1), HIGHLIGHT_STYLE); // "A0"
     pretty_assertions::assert_eq!(buffer, expected);
+
+    app.handle_event(Event::Key(KeyCode::Up.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "List A                                                                         ▲",
+        "    (X) A0                                                                     █",
+        "    ( ) A1                                                                     █",
+        "    ( ) A2                                                                     █",
+        "    ( ) A3                                                                     █",
+        "    ( ) A4                                                                     █",
+        "    ( ) A5                                                                     ▒",
+        "    ( ) A6                                                                     ▒",
+        "    ( ) A7                                                                     ▒",
+        "    ( ) A8                                                                     ▒",
+        "    ( ) A9                                                                     ▒",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    ▒",
+        "    ( ) A13                                                                    ▒",
+        "    ( ) A14                                                                    ▒",
+        "    ( ) A15                                                                    ▒",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 0, 79, 1), TITLE_STYLE); // "List A"
+    expected.set_style(Rect::new(0, 18, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 1, 7, 1), HIGHLIGHT_STYLE); // "A0"
+    pretty_assertions::assert_eq!(buffer, expected);
+
+    app.handle_event(Event::Key(KeyCode::Up.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    pretty_assertions::assert_eq!(buffer, expected);
 }
 
 #[test]

--- a/src/app/tests/multipage.rs
+++ b/src/app/tests/multipage.rs
@@ -697,3 +697,81 @@ fn page_down() {
     expected.set_style(Rect::new(4, 0, 7, 1), HIGHLIGHT_STYLE); // "B5"
     pretty_assertions::assert_eq!(buffer, expected);
 }
+
+#[test]
+fn page_down_twice_then_page_up() {
+    let mut app = App::from(mkform());
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    app.handle_event(Event::Key(KeyCode::PageDown.into()));
+    assert!(app.get_output().is_none());
+    app.handle_event(Event::Key(KeyCode::PageDown.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    ( ) C10                                                                    ▲",
+        "    ( ) C11                                                                    ▒",
+        "    ( ) C12                                                                    ▒",
+        "    ( ) C13                                                                    ▒",
+        "    ( ) C14                                                                    ▒",
+        "    ( ) C15                                                                    ▒",
+        "    ( ) C16                                                                    ▒",
+        "    ( ) C17                                                                    ▒",
+        "                                                                               ▒",
+        "List D                                                                         ▒",
+        "    (X) D0                                                                     ▒",
+        "    ( ) D1                                                                     █",
+        "    ( ) D2                                                                     █",
+        "    ( ) D3                                                                     █",
+        "    ( ) D4                                                                     █",
+        "    ( ) D5                                                                     █",
+        "    ( ) D6                                                                     █",
+        "    ( ) D7                                                                     ▒",
+        "    ( ) D8                                                                     ▒",
+        "    ( ) D9                                                                     ▒",
+        "    ( ) D10                                                                    ▒",
+        "    ( ) D11                                                                    ▒",
+        "    ( ) D12                                                                    ▒",
+        "    ( ) D13                                                                    ▼",
+    ]);
+    expected.set_style(Rect::new(0, 9, 79, 1), TITLE_STYLE); // "List D"
+    expected.set_style(Rect::new(4, 0, 7, 1), HIGHLIGHT_STYLE); // "C10"
+    pretty_assertions::assert_eq!(buffer, expected);
+
+    app.handle_event(Event::Key(KeyCode::PageUp.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    ( ) B5                                                                     ▲",
+        "    ( ) B6                                                                     ▒",
+        "    ( ) B7                                                                     ▒",
+        "    ( ) B8                                                                     ▒",
+        "    ( ) B9                                                                     ▒",
+        "    ( ) B10                                                                    ▒",
+        "    ( ) B11                                                                    █",
+        "    ( ) B12                                                                    █",
+        "    ( ) B13                                                                    █",
+        "    ( ) B14                                                                    █",
+        "    ( ) B15                                                                    █",
+        "    ( ) B16                                                                    ▒",
+        "                                                                               ▒",
+        "List C                                                                         ▒",
+        "    (X) C0                                                                     ▒",
+        "    ( ) C1                                                                     ▒",
+        "    ( ) C2                                                                     ▒",
+        "    ( ) C3                                                                     ▒",
+        "    ( ) C4                                                                     ▒",
+        "    ( ) C5                                                                     ▒",
+        "    ( ) C6                                                                     ▒",
+        "    ( ) C7                                                                     ▒",
+        "    ( ) C8                                                                     ▒",
+        "    ( ) C9                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 13, 79, 1), TITLE_STYLE); // "List C"
+    expected.set_style(Rect::new(4, 23, 7, 1), HIGHLIGHT_STYLE); // "C9"
+    pretty_assertions::assert_eq!(buffer, expected);
+}

--- a/src/app/tests/multipage.rs
+++ b/src/app/tests/multipage.rs
@@ -261,3 +261,163 @@ fn scroll_down_across_list() {
     expected.set_style(Rect::new(4, 23, 7, 1), HIGHLIGHT_STYLE); // "C0"
     pretty_assertions::assert_eq!(buffer, expected);
 }
+
+#[test]
+fn scroll_down_one_line_then_goto_top() {
+    let mut app = App::from(mkform());
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    for _ in 0..21 {
+        app.handle_event(Event::Key(KeyCode::Down.into()));
+        assert!(app.get_output().is_none());
+    }
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    (X) A0                                                                     ▲",
+        "    ( ) A1                                                                     █",
+        "    ( ) A2                                                                     █",
+        "    ( ) A3                                                                     █",
+        "    ( ) A4                                                                     █",
+        "    ( ) A5                                                                     █",
+        "    ( ) A6                                                                     ▒",
+        "    ( ) A7                                                                     ▒",
+        "    ( ) A8                                                                     ▒",
+        "    ( ) A9                                                                     ▒",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    ▒",
+        "    ( ) A13                                                                    ▒",
+        "    ( ) A14                                                                    ▒",
+        "    ( ) A15                                                                    ▒",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▒",
+        "    ( ) B5                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 17, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 23, 7, 1), HIGHLIGHT_STYLE); // "B5"
+    pretty_assertions::assert_eq!(buffer, expected);
+
+    app.handle_event(Event::Key(KeyCode::Home.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    let mut expected = Buffer::with_lines([
+        "List A                                                                         ▲",
+        "    (X) A0                                                                     █",
+        "    ( ) A1                                                                     █",
+        "    ( ) A2                                                                     █",
+        "    ( ) A3                                                                     █",
+        "    ( ) A4                                                                     █",
+        "    ( ) A5                                                                     ▒",
+        "    ( ) A6                                                                     ▒",
+        "    ( ) A7                                                                     ▒",
+        "    ( ) A8                                                                     ▒",
+        "    ( ) A9                                                                     ▒",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    ▒",
+        "    ( ) A13                                                                    ▒",
+        "    ( ) A14                                                                    ▒",
+        "    ( ) A15                                                                    ▒",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 0, 79, 1), TITLE_STYLE); // "List A"
+    expected.set_style(Rect::new(0, 18, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 1, 7, 1), HIGHLIGHT_STYLE); // "A0"
+    pretty_assertions::assert_eq!(buffer, expected);
+}
+
+#[test]
+fn scroll_down_more_then_goto_top() {
+    let mut app = App::from(mkform());
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    for _ in 0..30 {
+        app.handle_event(Event::Key(KeyCode::Down.into()));
+        assert!(app.get_output().is_none());
+    }
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    ( ) A9                                                                     ▲",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    █",
+        "    ( ) A13                                                                    █",
+        "    ( ) A14                                                                    █",
+        "    ( ) A15                                                                    █",
+        "                                                                               █",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▒",
+        "    ( ) B5                                                                     ▒",
+        "    ( ) B6                                                                     ▒",
+        "    ( ) B7                                                                     ▒",
+        "    ( ) B8                                                                     ▒",
+        "    ( ) B9                                                                     ▒",
+        "    ( ) B10                                                                    ▒",
+        "    ( ) B11                                                                    ▒",
+        "    ( ) B12                                                                    ▒",
+        "    ( ) B13                                                                    ▒",
+        "    ( ) B14                                                                    ▼",
+    ]);
+    expected.set_style(Rect::new(0, 8, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 23, 7, 1), HIGHLIGHT_STYLE); // "B14"
+    pretty_assertions::assert_eq!(buffer, expected);
+
+    app.handle_event(Event::Key(KeyCode::Home.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    let mut expected = Buffer::with_lines([
+        "List A                                                                         ▲",
+        "    (X) A0                                                                     █",
+        "    ( ) A1                                                                     █",
+        "    ( ) A2                                                                     █",
+        "    ( ) A3                                                                     █",
+        "    ( ) A4                                                                     █",
+        "    ( ) A5                                                                     ▒",
+        "    ( ) A6                                                                     ▒",
+        "    ( ) A7                                                                     ▒",
+        "    ( ) A8                                                                     ▒",
+        "    ( ) A9                                                                     ▒",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    ▒",
+        "    ( ) A13                                                                    ▒",
+        "    ( ) A14                                                                    ▒",
+        "    ( ) A15                                                                    ▒",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 0, 79, 1), TITLE_STYLE); // "List A"
+    expected.set_style(Rect::new(0, 18, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 1, 7, 1), HIGHLIGHT_STYLE); // "A0"
+    pretty_assertions::assert_eq!(buffer, expected);
+}

--- a/src/app/tests/multipage.rs
+++ b/src/app/tests/multipage.rs
@@ -1,3 +1,6 @@
+// IMPORTANT: In these tests, `app.render()` needs to be called before the
+// first call to `app.handle_event()` so that the `App` fills in the screen
+// height in the former call for use in the latter.
 use crate::app::*;
 use ratatui::{buffer::Buffer, layout::Rect};
 
@@ -6,7 +9,7 @@ mod areas {
 
     pub(super) const SCREEN: Rect = Rect::new(0, 0, 80, 24);
 
-    //pub(super) const OK: Rect = Rect::new(27, 23, 4, 1);
+    pub(super) const OK: Rect = Rect::new(27, 23, 4, 1);
     //pub(super) const CANCEL: Rect = Rect::new(46, 23, 8, 1);
 }
 
@@ -56,5 +59,47 @@ fn draw_multipage() {
     expected.set_style(Rect::new(0, 0, 79, 1), TITLE_STYLE); // "List A"
     expected.set_style(Rect::new(0, 18, 79, 1), TITLE_STYLE); // "List B"
     expected.set_style(Rect::new(4, 1, 7, 1), HIGHLIGHT_STYLE); // "A0"
+    pretty_assertions::assert_eq!(buffer, expected);
+}
+
+#[test]
+fn goto_bottom() {
+    let mut app = App::from(mkform());
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    app.handle_event(Event::Key(KeyCode::End.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "                                                                               ▲",
+        "List E                                                                         ▒",
+        "    (X) E0                                                                     ▒",
+        "    ( ) E1                                                                     ▒",
+        "    ( ) E2                                                                     ▒",
+        "    ( ) E3                                                                     ▒",
+        "    ( ) E4                                                                     ▒",
+        "    ( ) E5                                                                     ▒",
+        "    ( ) E6                                                                     ▒",
+        "    ( ) E7                                                                     ▒",
+        "    ( ) E8                                                                     ▒",
+        "    ( ) E9                                                                     ▒",
+        "    ( ) E10                                                                    ▒",
+        "    ( ) E11                                                                    ▒",
+        "    ( ) E12                                                                    ▒",
+        "    ( ) E13                                                                    ▒",
+        "    ( ) E14                                                                    ▒",
+        "    ( ) E15                                                                    ▒",
+        "    ( ) E16                                                                    █",
+        "    ( ) E17                                                                    █",
+        "    ( ) E18                                                                    █",
+        "    ( ) E19                                                                    █",
+        "                                                                               █",
+        "                           <OK>               <Cancel>                         ▼",
+    ]);
+    expected.set_style(Rect::new(0, 1, 79, 1), TITLE_STYLE); // "List E"
+    expected.set_style(areas::OK, HIGHLIGHT_STYLE);
     pretty_assertions::assert_eq!(buffer, expected);
 }

--- a/src/app/tests/multipage.rs
+++ b/src/app/tests/multipage.rs
@@ -1,0 +1,60 @@
+use crate::app::*;
+use ratatui::{buffer::Buffer, layout::Rect};
+
+mod areas {
+    use super::*;
+
+    pub(super) const SCREEN: Rect = Rect::new(0, 0, 80, 24);
+
+    //pub(super) const OK: Rect = Rect::new(27, 23, 4, 1);
+    //pub(super) const CANCEL: Rect = Rect::new(46, 23, 8, 1);
+}
+
+fn mkform() -> Form<char> {
+    let mut form = Form::new();
+    for (ch, qty) in std::iter::zip("ABCDE".chars(), 16..) {
+        form.add(
+            ch,
+            RadioSelector::new(format!("List {ch}"), (0..qty).map(|i| format!("{ch}{i}"))),
+        );
+    }
+    form
+}
+
+#[test]
+fn draw_multipage() {
+    let mut app = App::from(mkform());
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "List A                                                                         ▲",
+        "    (X) A0                                                                     █",
+        "    ( ) A1                                                                     █",
+        "    ( ) A2                                                                     █",
+        "    ( ) A3                                                                     █",
+        "    ( ) A4                                                                     █",
+        "    ( ) A5                                                                     ▒",
+        "    ( ) A6                                                                     ▒",
+        "    ( ) A7                                                                     ▒",
+        "    ( ) A8                                                                     ▒",
+        "    ( ) A9                                                                     ▒",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    ▒",
+        "    ( ) A13                                                                    ▒",
+        "    ( ) A14                                                                    ▒",
+        "    ( ) A15                                                                    ▒",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 0, 79, 1), TITLE_STYLE); // "List A"
+    expected.set_style(Rect::new(0, 18, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 1, 7, 1), HIGHLIGHT_STYLE); // "A0"
+    pretty_assertions::assert_eq!(buffer, expected);
+}

--- a/src/app/tests/multipage.rs
+++ b/src/app/tests/multipage.rs
@@ -655,3 +655,45 @@ fn scroll_down_more_then_scroll_up_one() {
     expected.set_style(Rect::new(4, 0, 7, 1), HIGHLIGHT_STYLE); // "A8"
     pretty_assertions::assert_eq!(buffer, expected);
 }
+
+#[test]
+fn page_down() {
+    let mut app = App::from(mkform());
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    app.handle_event(Event::Key(KeyCode::PageDown.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    ( ) B5                                                                     ▲",
+        "    ( ) B6                                                                     ▒",
+        "    ( ) B7                                                                     ▒",
+        "    ( ) B8                                                                     ▒",
+        "    ( ) B9                                                                     ▒",
+        "    ( ) B10                                                                    ▒",
+        "    ( ) B11                                                                    █",
+        "    ( ) B12                                                                    █",
+        "    ( ) B13                                                                    █",
+        "    ( ) B14                                                                    █",
+        "    ( ) B15                                                                    █",
+        "    ( ) B16                                                                    ▒",
+        "                                                                               ▒",
+        "List C                                                                         ▒",
+        "    (X) C0                                                                     ▒",
+        "    ( ) C1                                                                     ▒",
+        "    ( ) C2                                                                     ▒",
+        "    ( ) C3                                                                     ▒",
+        "    ( ) C4                                                                     ▒",
+        "    ( ) C5                                                                     ▒",
+        "    ( ) C6                                                                     ▒",
+        "    ( ) C7                                                                     ▒",
+        "    ( ) C8                                                                     ▒",
+        "    ( ) C9                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 13, 79, 1), TITLE_STYLE); // "List C"
+    expected.set_style(Rect::new(4, 0, 7, 1), HIGHLIGHT_STYLE); // "B5"
+    pretty_assertions::assert_eq!(buffer, expected);
+}

--- a/src/app/tests/multipage.rs
+++ b/src/app/tests/multipage.rs
@@ -389,7 +389,6 @@ fn scroll_down_more_then_goto_top() {
     assert!(app.get_output().is_none());
     let mut buffer = Buffer::empty(areas::SCREEN);
     app.render(areas::SCREEN, &mut buffer);
-
     let mut expected = Buffer::with_lines([
         "List A                                                                         ▲",
         "    (X) A0                                                                     █",
@@ -419,5 +418,199 @@ fn scroll_down_more_then_goto_top() {
     expected.set_style(Rect::new(0, 0, 79, 1), TITLE_STYLE); // "List A"
     expected.set_style(Rect::new(0, 18, 79, 1), TITLE_STYLE); // "List B"
     expected.set_style(Rect::new(4, 1, 7, 1), HIGHLIGHT_STYLE); // "A0"
+    pretty_assertions::assert_eq!(buffer, expected);
+}
+
+#[test]
+fn scroll_down_one_line_then_back_up() {
+    let mut app = App::from(mkform());
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    for _ in 0..21 {
+        app.handle_event(Event::Key(KeyCode::Down.into()));
+        assert!(app.get_output().is_none());
+    }
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    (X) A0                                                                     ▲",
+        "    ( ) A1                                                                     █",
+        "    ( ) A2                                                                     █",
+        "    ( ) A3                                                                     █",
+        "    ( ) A4                                                                     █",
+        "    ( ) A5                                                                     █",
+        "    ( ) A6                                                                     ▒",
+        "    ( ) A7                                                                     ▒",
+        "    ( ) A8                                                                     ▒",
+        "    ( ) A9                                                                     ▒",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    ▒",
+        "    ( ) A13                                                                    ▒",
+        "    ( ) A14                                                                    ▒",
+        "    ( ) A15                                                                    ▒",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▒",
+        "    ( ) B5                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 17, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 23, 7, 1), HIGHLIGHT_STYLE); // "B5"
+    pretty_assertions::assert_eq!(buffer, expected);
+
+    for _ in 0..21 {
+        app.handle_event(Event::Key(KeyCode::Up.into()));
+        assert!(app.get_output().is_none());
+    }
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    (X) A0                                                                     ▲",
+        "    ( ) A1                                                                     █",
+        "    ( ) A2                                                                     █",
+        "    ( ) A3                                                                     █",
+        "    ( ) A4                                                                     █",
+        "    ( ) A5                                                                     █",
+        "    ( ) A6                                                                     ▒",
+        "    ( ) A7                                                                     ▒",
+        "    ( ) A8                                                                     ▒",
+        "    ( ) A9                                                                     ▒",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    ▒",
+        "    ( ) A13                                                                    ▒",
+        "    ( ) A14                                                                    ▒",
+        "    ( ) A15                                                                    ▒",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▒",
+        "    ( ) B5                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 17, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 0, 7, 1), HIGHLIGHT_STYLE); // "A0"
+    pretty_assertions::assert_eq!(buffer, expected);
+}
+
+#[test]
+fn scroll_down_more_then_scroll_up_one() {
+    let mut app = App::from(mkform());
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    for _ in 0..30 {
+        app.handle_event(Event::Key(KeyCode::Down.into()));
+        assert!(app.get_output().is_none());
+    }
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    ( ) A9                                                                     ▲",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    █",
+        "    ( ) A13                                                                    █",
+        "    ( ) A14                                                                    █",
+        "    ( ) A15                                                                    █",
+        "                                                                               █",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▒",
+        "    ( ) B5                                                                     ▒",
+        "    ( ) B6                                                                     ▒",
+        "    ( ) B7                                                                     ▒",
+        "    ( ) B8                                                                     ▒",
+        "    ( ) B9                                                                     ▒",
+        "    ( ) B10                                                                    ▒",
+        "    ( ) B11                                                                    ▒",
+        "    ( ) B12                                                                    ▒",
+        "    ( ) B13                                                                    ▒",
+        "    ( ) B14                                                                    ▼",
+    ]);
+    expected.set_style(Rect::new(0, 8, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 23, 7, 1), HIGHLIGHT_STYLE); // "B14"
+    pretty_assertions::assert_eq!(buffer, expected);
+
+    for _ in 0..21 {
+        app.handle_event(Event::Key(KeyCode::Up.into()));
+        assert!(app.get_output().is_none());
+    }
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    ( ) A9                                                                     ▲",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    █",
+        "    ( ) A13                                                                    █",
+        "    ( ) A14                                                                    █",
+        "    ( ) A15                                                                    █",
+        "                                                                               █",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▒",
+        "    ( ) B5                                                                     ▒",
+        "    ( ) B6                                                                     ▒",
+        "    ( ) B7                                                                     ▒",
+        "    ( ) B8                                                                     ▒",
+        "    ( ) B9                                                                     ▒",
+        "    ( ) B10                                                                    ▒",
+        "    ( ) B11                                                                    ▒",
+        "    ( ) B12                                                                    ▒",
+        "    ( ) B13                                                                    ▒",
+        "    ( ) B14                                                                    ▼",
+    ]);
+    expected.set_style(Rect::new(0, 8, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 0, 7, 1), HIGHLIGHT_STYLE); // "A9"
+    pretty_assertions::assert_eq!(buffer, expected);
+
+    app.handle_event(Event::Key(KeyCode::Up.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    ( ) A8                                                                     ▲",
+        "    ( ) A9                                                                     ▒",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    █",
+        "    ( ) A12                                                                    █",
+        "    ( ) A13                                                                    █",
+        "    ( ) A14                                                                    █",
+        "    ( ) A15                                                                    █",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▒",
+        "    ( ) B5                                                                     ▒",
+        "    ( ) B6                                                                     ▒",
+        "    ( ) B7                                                                     ▒",
+        "    ( ) B8                                                                     ▒",
+        "    ( ) B9                                                                     ▒",
+        "    ( ) B10                                                                    ▒",
+        "    ( ) B11                                                                    ▒",
+        "    ( ) B12                                                                    ▒",
+        "    ( ) B13                                                                    ▼",
+    ]);
+    expected.set_style(Rect::new(0, 9, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 0, 7, 1), HIGHLIGHT_STYLE); // "A8"
     pretty_assertions::assert_eq!(buffer, expected);
 }

--- a/src/app/tests/multipage.rs
+++ b/src/app/tests/multipage.rs
@@ -103,3 +103,161 @@ fn goto_bottom() {
     expected.set_style(areas::OK, HIGHLIGHT_STYLE);
     pretty_assertions::assert_eq!(buffer, expected);
 }
+
+#[test]
+fn scroll_down_one_line() {
+    let mut app = App::from(mkform());
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    for _ in 0..20 {
+        app.handle_event(Event::Key(KeyCode::Down.into()));
+        assert!(app.get_output().is_none());
+    }
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "List A                                                                         ▲",
+        "    (X) A0                                                                     █",
+        "    ( ) A1                                                                     █",
+        "    ( ) A2                                                                     █",
+        "    ( ) A3                                                                     █",
+        "    ( ) A4                                                                     █",
+        "    ( ) A5                                                                     ▒",
+        "    ( ) A6                                                                     ▒",
+        "    ( ) A7                                                                     ▒",
+        "    ( ) A8                                                                     ▒",
+        "    ( ) A9                                                                     ▒",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    ▒",
+        "    ( ) A13                                                                    ▒",
+        "    ( ) A14                                                                    ▒",
+        "    ( ) A15                                                                    ▒",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 0, 79, 1), TITLE_STYLE); // "List A"
+    expected.set_style(Rect::new(0, 18, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 23, 7, 1), HIGHLIGHT_STYLE); // "B4"
+    pretty_assertions::assert_eq!(buffer, expected);
+
+    app.handle_event(Event::Key(KeyCode::Down.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    (X) A0                                                                     ▲",
+        "    ( ) A1                                                                     █",
+        "    ( ) A2                                                                     █",
+        "    ( ) A3                                                                     █",
+        "    ( ) A4                                                                     █",
+        "    ( ) A5                                                                     █",
+        "    ( ) A6                                                                     ▒",
+        "    ( ) A7                                                                     ▒",
+        "    ( ) A8                                                                     ▒",
+        "    ( ) A9                                                                     ▒",
+        "    ( ) A10                                                                    ▒",
+        "    ( ) A11                                                                    ▒",
+        "    ( ) A12                                                                    ▒",
+        "    ( ) A13                                                                    ▒",
+        "    ( ) A14                                                                    ▒",
+        "    ( ) A15                                                                    ▒",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     ▒",
+        "    ( ) B1                                                                     ▒",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▒",
+        "    ( ) B5                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 17, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 23, 7, 1), HIGHLIGHT_STYLE); // "B5"
+    pretty_assertions::assert_eq!(buffer, expected);
+}
+
+#[test]
+fn scroll_down_across_list() {
+    let mut app = App::from(mkform());
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+
+    for _ in 0..32 {
+        app.handle_event(Event::Key(KeyCode::Down.into()));
+        assert!(app.get_output().is_none());
+    }
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    ( ) A11                                                                    ▲",
+        "    ( ) A12                                                                    ▒",
+        "    ( ) A13                                                                    ▒",
+        "    ( ) A14                                                                    ▒",
+        "    ( ) A15                                                                    █",
+        "                                                                               █",
+        "List B                                                                         █",
+        "    (X) B0                                                                     █",
+        "    ( ) B1                                                                     █",
+        "    ( ) B2                                                                     ▒",
+        "    ( ) B3                                                                     ▒",
+        "    ( ) B4                                                                     ▒",
+        "    ( ) B5                                                                     ▒",
+        "    ( ) B6                                                                     ▒",
+        "    ( ) B7                                                                     ▒",
+        "    ( ) B8                                                                     ▒",
+        "    ( ) B9                                                                     ▒",
+        "    ( ) B10                                                                    ▒",
+        "    ( ) B11                                                                    ▒",
+        "    ( ) B12                                                                    ▒",
+        "    ( ) B13                                                                    ▒",
+        "    ( ) B14                                                                    ▒",
+        "    ( ) B15                                                                    ▒",
+        "    ( ) B16                                                                    ▼",
+    ]);
+    expected.set_style(Rect::new(0, 6, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(4, 23, 7, 1), HIGHLIGHT_STYLE); // "B16"
+    pretty_assertions::assert_eq!(buffer, expected);
+
+    app.handle_event(Event::Key(KeyCode::Down.into()));
+    assert!(app.get_output().is_none());
+    let mut buffer = Buffer::empty(areas::SCREEN);
+    app.render(areas::SCREEN, &mut buffer);
+    let mut expected = Buffer::with_lines([
+        "    ( ) A14                                                                    ▲",
+        "    ( ) A15                                                                    ▒",
+        "                                                                               ▒",
+        "List B                                                                         ▒",
+        "    (X) B0                                                                     █",
+        "    ( ) B1                                                                     █",
+        "    ( ) B2                                                                     █",
+        "    ( ) B3                                                                     █",
+        "    ( ) B4                                                                     █",
+        "    ( ) B5                                                                     ▒",
+        "    ( ) B6                                                                     ▒",
+        "    ( ) B7                                                                     ▒",
+        "    ( ) B8                                                                     ▒",
+        "    ( ) B9                                                                     ▒",
+        "    ( ) B10                                                                    ▒",
+        "    ( ) B11                                                                    ▒",
+        "    ( ) B12                                                                    ▒",
+        "    ( ) B13                                                                    ▒",
+        "    ( ) B14                                                                    ▒",
+        "    ( ) B15                                                                    ▒",
+        "    ( ) B16                                                                    ▒",
+        "                                                                               ▒",
+        "List C                                                                         ▒",
+        "    (X) C0                                                                     ▼",
+    ]);
+    expected.set_style(Rect::new(0, 3, 79, 1), TITLE_STYLE); // "List B"
+    expected.set_style(Rect::new(0, 22, 79, 1), TITLE_STYLE); // "List C"
+    expected.set_style(Rect::new(4, 23, 7, 1), HIGHLIGHT_STYLE); // "C0"
+    pretty_assertions::assert_eq!(buffer, expected);
+}


### PR DESCRIPTION
Closes #34.
Builds on top of #31.

To Do:

- [ ] Reconsider how moving up/down a page is implemented/computed
    - Move the focus up/down by enough items to fill a page, then readjust the scroll offset?
- [ ] Document paging keybindings in README